### PR TITLE
Readme: update NEON format homepage URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ----
 
 This repository is for education. The main goal is to show how to define services in cool Nette Dependency-Injection Container (nette/di).
-The examples are written in NEON (take a look at [ne-on.org](https://ne-on.org)) and in PHP classes called `CompilerExtension`.
+The examples are written in NEON (take a look at [neon.nette.org](https://neon.nette.org)) and in PHP classes called `CompilerExtension`.
 
 Related blogposts:
 - https://f3l1x.io/blog/2015/10/17/nette-jak-zapisovat-sluzby/


### PR DESCRIPTION
Updates the homepage URL of NEON format after domain ne-on.org expired.